### PR TITLE
Sync config files to best practices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv sync *)",
+      "Bash(uv run ansible-lint *)",
+      "Bash(uv run yamllint *)",
+      "Bash(uv run flake8 *)",
+      "Bash(uv run pre-commit run *)",
+      "Bash(uv run molecule list *)",
+      "Bash(uv run molecule check *)",
+      "Bash(uv run molecule syntax *)",
+      "Bash(uv run molecule create *)",
+      "Bash(uv run molecule converge *)",
+      "Bash(uv run molecule idempotence *)",
+      "Bash(uv run molecule verify *)",
+      "Bash(uv run molecule test *)",
+      "Bash(uv run molecule destroy *)",
+      "Bash(uv run molecule prepare *)",
+      "Bash(uv run molecule side-effect *)",
+      "Bash(uv run molecule cleanup *)",
+      "Bash(uv run pytest *)",
+      "Bash(uv lock *)",
+      "Bash(uv python *)",
+      "Bash(uv pip list *)",
+      "Bash(uv pip show *)",
+      "Bash(uv tree *)",
+      "Bash(uv version *)",
+      "WebFetch(domain:docs.ansible.com)",
+      "WebFetch(domain:ansible.readthedocs.io)",
+      "WebFetch(domain:molecule.readthedocs.io)",
+      "WebFetch(domain:yamllint.readthedocs.io)",
+      "WebFetch(domain:flake8.pycqa.org)",
+      "WebFetch(domain:docs.astral.sh)",
+      "WebFetch(domain:galaxy.ansible.com)",
+      "WebFetch(domain:pre-commit.com)",
+      "WebFetch(domain:testinfra.readthedocs.io)",
+      "WebFetch(domain:docs.docker.com)",
+      "WebFetch(domain:jinja.palletsprojects.com)"
+    ],
+    "ask": [
+      "Bash(uv run ansible *)",
+      "Bash(uv run python *)",
+      "Bash(uv run ansible-galaxy *)",
+      "Bash(uv add *)",
+      "Bash(uv remove *)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
@@ -39,7 +39,8 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: ubuntu-22.04
+    needs: lint
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+---
 name: Publish Role to Galaxy
 
-on: # yamllint disable-line rule:truthy
+'on':
   release:
     types: [published]
 
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up uv.
         uses: astral-sh/setup-uv@v5
@@ -19,5 +20,8 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --api-key "$GALAXY_API_KEY"
+          "${GITHUB_REPOSITORY%/*}" "${GITHUB_REPOSITORY#*/}"
+        env:
+          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,43 @@ Role variables are in `defaults/main.yml` (repo URL, destination, host key accep
 - `.yamllint` allows up to 160-character lines
 - Pre-commit hooks use `language: system` (tools must be installed in the active virtualenv)
 
-## CI Note
+## CI
 
-CI checks out the repo into a directory named `brianhartsock.zprezto` so molecule can resolve the role name correctly. Locally this is not required.
+CI runs on `ubuntu-latest` via GitHub Actions (`.github/workflows/ci.yml`) with two jobs:
+
+1. **Lint** -- runs `ansible-lint`, `yamllint`, and `flake8`
+2. **Molecule** (`needs: lint`) -- runs both the default and `check_mode` molecule scenarios
+
+Both jobs check out the repo into a directory named `brianhartsock.zprezto` so molecule can resolve the role name correctly. Locally this is not required.
+
+A separate release workflow (`.github/workflows/release.yml`) publishes the role to Ansible Galaxy on GitHub release events.
+
+## Development Workflow
+
+Follow this workflow for all code changes.
+
+```
+Code → Document → Verify → Code Review
+  ^                              |
+  └──── fix issues ──────────────┘
+```
+
+### 1. Code
+
+Make the implementation changes. Use FQCNs, name all tasks, and follow the patterns in existing task files.
+
+### 2. Document
+
+Update README.md and CLAUDE.md to reflect any changes to variables, platforms, commands, or architecture. If the ansible plugin is installed, use the `documentator` agent.
+
+### 3. Verify
+
+Run linters (yamllint, ansible-lint, flake8), pre-commit hooks, and molecule tests. All checks must pass before proceeding. If the ansible plugin is installed, use the `verifier` agent.
+
+### 4. Code Review
+
+Review the changes for Ansible best practices, idempotency, security, cross-platform correctness, and test coverage. If the ansible plugin is installed, use the `code-reviewer` agent.
+
+### 5. Iterate
+
+If verification or code review flags issues, fix them and repeat from step 2. Continue until all checks pass and the review is clean.

--- a/molecule/check_mode/molecule.yml
+++ b/molecule/check_mode/molecule.yml
@@ -7,6 +7,8 @@ platforms:
   # Only worry about noble for check mode since there is no difference in playbooks
   - name: noble
     image: ubuntu:24.04
+    env:
+      USER: root
 provisioner:
   name: ansible
   options:


### PR DESCRIPTION
## Summary

- **CI workflow**: Upgrade runners from `ubuntu-22.04` to `ubuntu-latest`; add `needs: lint` so molecule runs only after lint passes
- **Release workflow**: Upgrade `actions/checkout` v3→v4; quote `'on:'` key; move secrets to `env:` block to prevent shell injection
- **Molecule check_mode**: Add `env: USER: root` so `ansible_env.USER` is available in containers
- **Claude Code**: Add `.claude/settings.json` with standard permissions for linters, molecule, and docs domains
- **CLAUDE.md**: Expand CI section to document two-job structure; add Development Workflow section

## Test plan

- [ ] CI lint job passes (yamllint, ansible-lint, flake8)
- [ ] CI molecule job passes (default + check_mode scenarios)
- [ ] Release workflow syntax is valid (Galaxy publish on release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)