### PR TITLE
Add Dependabot grouping and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+---
+name: Dependabot Auto-Merge
+
+'on': pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and merge eligible updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="brianhartsock/ansible-role-prezto"
+BRANCH="master"
+REQUIRED_CHECKS=("Lint" "Molecule")
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+    CHECK_ONLY=true
+fi
+
+echo "Repository: $REPO"
+echo "Branch:     $BRANCH"
+echo "Required:   ${REQUIRED_CHECKS[*]}"
+echo
+
+# Fetch current branch protection
+echo "=== Current Branch Protection ==="
+PROTECTION=$(gh api "repos/$REPO/branches/$BRANCH/protection" 2>/dev/null || echo "none")
+
+if [[ "$PROTECTION" == "none" ]]; then
+    echo "No branch protection rules configured."
+    CURRENT_CHECKS=()
+else
+    CURRENT_CHECKS=($(echo "$PROTECTION" | jq -r '.required_status_checks.contexts[]? // empty' 2>/dev/null))
+    if [[ ${#CURRENT_CHECKS[@]} -eq 0 ]]; then
+        echo "Branch protection exists but no required status checks."
+    else
+        echo "Current required checks:"
+        for check in "${CURRENT_CHECKS[@]}"; do
+            echo "  - $check"
+        done
+    fi
+fi
+echo
+
+# Report missing checks
+MISSING=()
+for check in "${REQUIRED_CHECKS[@]}"; do
+    found=false
+    for current in "${CURRENT_CHECKS[@]+"${CURRENT_CHECKS[@]}"}"; do
+        if [[ "$current" == "$check" ]]; then
+            found=true
+            break
+        fi
+    done
+    if [[ "$found" == "false" ]]; then
+        MISSING+=("$check")
+    fi
+done
+
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+    echo "All required checks are configured."
+    exit 0
+fi
+
+echo "Missing checks:"
+for check in "${MISSING[@]}"; do
+    echo "  - $check"
+done
+echo
+
+if [[ "$CHECK_ONLY" == "true" ]]; then
+    echo "Run without --check to apply changes."
+    exit 1
+fi
+
+# Build the required_status_checks JSON
+CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s .)
+
+echo "=== Configuring Branch Protection ==="
+gh api "repos/$REPO/branches/$BRANCH/protection" \
+    --method PUT \
+    --input - <<EOF
+{
+    "required_status_checks": {
+        "strict": true,
+        "contexts": $CHECKS_JSON
+    },
+    "enforce_admins": false,
+    "required_pull_request_reviews": null,
+    "restrictions": null
+}
+EOF
+
+echo
+echo "=== Verifying Configuration ==="
+UPDATED=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks")
+echo "Required checks after update:"
+echo "$UPDATED" | jq -r '.contexts[]'
+echo
+echo "Branch protection configured successfully."


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to group all pip and github-actions updates into single weekly PRs
- Add `.github/workflows/dependabot-auto-merge.yml` to auto-approve and squash-merge patch/minor Dependabot PRs after CI passes
- Add `scripts/configure-branch-protection.sh` to check/configure required status checks (Lint, Molecule) for branch protection

## Test plan
- [ ] Verify Dependabot opens grouped PRs on the next weekly schedule
- [ ] Verify patch/minor Dependabot PRs are auto-approved and merged after CI passes
- [ ] Verify major Dependabot PRs require manual review
- [ ] Run `./scripts/configure-branch-protection.sh --check` to confirm branch protection state

🤖 Generated with [Claude Code](https://claude.com/claude-code)